### PR TITLE
reduce RandomAccessDataObject interface and simplify BufferedFile.finalize(); resolve #4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 sourceCompatibility = 1.8
 group = 'org.opencadc'
-version = '1.16.1'
+version = '1.16.2'
 
 dependencies {
     compile 'com.google.code.findbugs:annotations:[3.0,4.0)'

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 		<version>7</version>
 	</parent>
 	<groupId>org.opencadc</groupId>
-	<version>1.16.1</version>
+	<version>1.16.2</version>
 	<packaging>jar</packaging>
 	<artifactId>nom-tam-fits</artifactId>
 	<name>nom.tam FITS library</name>

--- a/src/main/java/nom/tam/util/BufferedFile.java
+++ b/src/main/java/nom/tam/util/BufferedFile.java
@@ -62,7 +62,6 @@ package nom.tam.util;
  */
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileDescriptor;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -316,12 +315,9 @@ public class BufferedFile implements ArrayDataOutput, RandomAccess {
     @Override
     protected void finalize() {
         try {
-            if (getFD().valid()) {
-                flush();
-                close();
-            }
-        } catch (Exception e) {
-            BufferedFile.LOG.log(Level.SEVERE, "could not finalize buffered file", e);
+            close();
+        } catch (IOException e) {
+            BufferedFile.LOG.log(Level.SEVERE, "could not flush and close buffered file", e);
         }
     }
 
@@ -345,9 +341,9 @@ public class BufferedFile implements ArrayDataOutput, RandomAccess {
      * 
      * @return the file channel
      */
-    public java.nio.channels.FileChannel getChannel() {
-        return this.randomAccessFile.getChannel();
-    }
+    //public java.nio.channels.FileChannel getChannel() {
+    //    return this.randomAccessFile.getChannel();
+    //}
 
     /**
      * Get the file descriptor associated with this stream. Note that this
@@ -357,9 +353,9 @@ public class BufferedFile implements ArrayDataOutput, RandomAccess {
      * @throws IOException
      *             if the descriptor could not be accessed.
      */
-    public FileDescriptor getFD() throws IOException {
-        return this.randomAccessFile.getFD();
-    }
+    //public FileDescriptor getFD() throws IOException {
+    //    return this.randomAccessFile.getFD();
+    //}
 
     /**
      * Get the current offset into the file.

--- a/src/main/java/nom/tam/util/RandomAccessDataObject.java
+++ b/src/main/java/nom/tam/util/RandomAccessDataObject.java
@@ -32,9 +32,7 @@ package nom.tam.util;
  */
 
 import java.io.Closeable;
-import java.io.FileDescriptor;
 import java.io.IOException;
-import java.nio.channels.FileChannel;
 
 /**
  * Minimal interface for underlying data object that supports random access. The
@@ -79,11 +77,4 @@ public interface RandomAccessDataObject extends Closeable {
     void write(int i) throws IOException;
     
     void writeUTF(String s) throws IOException;
-    
-    // misc methods: not likely implementable by anything not a File
-    
-    FileChannel getChannel();
-    
-    FileDescriptor getFD() throws IOException;
-
 }

--- a/src/test/java/nom/tam/util/BufferedFileTest.java
+++ b/src/test/java/nom/tam/util/BufferedFileTest.java
@@ -68,7 +68,7 @@ public class BufferedFileTest {
     public void testReadWrite() throws IOException {
         BufferedFile file = new BufferedFile("target/BufferedFileReadWrite", "rw");
         file.write(new byte[10]);
-        Assert.assertTrue(file.getChannel().isOpen());
+        //Assert.assertTrue(file.getChannel().isOpen());
         file.close();
         file = new BufferedFile("target/BufferedFileReadWrite", "rw");
         try {


### PR DESCRIPTION
remove getChannel() and getFD() methods from RandomAccessDataObject interface
change BufferedFile.finalize() so it just calls close()

I did verify that you can call close() multiple times on a RandomAccessFile without causing a failure.